### PR TITLE
feat: Add configurable response length limit

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -69,6 +69,9 @@ def load_or_create_config():
             "delay_per_character": 0.01
         }
 
+    if "max_response_length" not in config:
+        config["max_response_length"] = 450
+
     if sys.stdin.isatty():
         channels_input = input("Enter Twitch channels (comma separated): ").strip()
         channels = [c.strip().lstrip("#") for c in channels_input.split(",") if c.strip()]
@@ -121,6 +124,11 @@ def generate_ai_response(prompt: str, user, config) -> str:
         if not text:
             print("[ERROR] Gemini response empty, full JSON:", resp)
             return "Hmm… I couldn't come up with a response!"
+
+        max_length = config.get("max_response_length", 450)
+        if len(text) > max_length:
+            text = text[:max_length] + "..."
+
         return text
     except Exception as e:
         print(f"[ERROR] Gemini API call failed: {e}, full response: {r.text if 'r' in locals() else 'no response'}")

--- a/dashboard.py
+++ b/dashboard.py
@@ -30,12 +30,13 @@ def create_dashboard_app(bot):
             moderation = json.dumps(config.get("moderation", {}))
             personality_traits = json.dumps(config.get("personality_traits", {}))
             delay_settings = json.dumps(config.get("delay_settings", {}))
+            max_response_length = config.get("max_response_length", 450)
             print(f"Socials: {socials}")
             print(f"Commands: {commands}")
             print(f"Moderation: {moderation}")
             print(f"Personality Traits: {personality_traits}")
             print(f"Delay Settings: {delay_settings}")
-            return render_template("dashboard.html", personality=config["personality"], auto_chat_freq=config["auto_chat_freq"], socials=socials, commands=commands, moderation=moderation, personality_traits=personality_traits, delay_settings=delay_settings)
+            return render_template("dashboard.html", personality=config["personality"], auto_chat_freq=config["auto_chat_freq"], socials=socials, commands=commands, moderation=moderation, personality_traits=personality_traits, delay_settings=delay_settings, max_response_length=max_response_length)
         except Exception as e:
             print(f"Error in index route: {e}")
             return "Internal Server Error", 500
@@ -99,6 +100,16 @@ def create_dashboard_app(bot):
         emit("config_updated", config, broadcast=True)
         # Update the bot's config as well
         bot.config["delay_settings"] = config["delay_settings"]
+
+    @socketio.on("update_response_settings")
+    def handle_update_response_settings(data):
+        print(f"Updating response settings with: {data}")
+        config = load_config()
+        config["max_response_length"] = data.get("response_settings", {}).get("max_response_length", 450)
+        save_config(config)
+        emit("config_updated", config, broadcast=True)
+        # Update the bot's config as well
+        bot.config["max_response_length"] = config["max_response_length"]
 
     @socketio.on("get_user_data")
     def handle_get_user_data():

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -73,6 +73,16 @@
             <button onclick="refreshUserData()">Refresh User Data</button>
         </div>
         <div class="form-group">
+            <h2>Response Settings</h2>
+            <div id="response-settings-container">
+                <div>
+                    <label for="max-response-length">Max Response Length (characters):</label>
+                    <input type="number" id="max-response-length">
+                </div>
+                <button onclick="saveResponseSettings()">Save Response Settings</button>
+            </div>
+        </div>
+        <div class="form-group">
             <h2>Delay Settings</h2>
             <div id="delay-settings-container">
                 <div>
@@ -128,6 +138,7 @@
         const userExplorerContainer = document.getElementById("user-explorer-container");
         const baseDelayInput = document.getElementById("base-delay");
         const delayPerCharacterInput = document.getElementById("delay-per-character");
+        const maxResponseLengthInput = document.getElementById("max-response-length");
 
         freqInput.addEventListener("input", () => {
             freqVal.innerText = freqInput.value;
@@ -180,6 +191,9 @@
             const delaySettings = config.delay_settings || {};
             baseDelayInput.value = delaySettings.base_delay;
             delayPerCharacterInput.value = delaySettings.delay_per_character;
+
+            // Populate response settings
+            maxResponseLengthInput.value = config.max_response_length;
 
             addLog("Config updated.");
         });
@@ -249,6 +263,13 @@
                 delay_per_character: parseFloat(delayPerCharacterInput.value)
             };
             socket.emit("update_delay_settings", {delay_settings: delaySettings});
+        }
+
+        function saveResponseSettings() {
+            const responseSettings = {
+                max_response_length: parseInt(maxResponseLengthInput.value)
+            };
+            socket.emit("update_response_settings", {response_settings: responseSettings});
         }
 
         function refreshUserData() {


### PR DESCRIPTION
This commit introduces a new setting, `max_response_length`, to control the maximum length of the bot's AI-generated responses. This prevents the bot from sending overly long messages that get broken down into multiple chunks and spam the chat.

The `max_response_length` can be configured from the new 'Response Settings' section on the dashboard.